### PR TITLE
Added Player Error and Display It to the User

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,7 +2,10 @@
 
 == Big Fig Wasp
 
-- Setup for f-droid release
+- Setup Foss and Full Variants for f-droid release
+- Added media player error state and cleaned up the PlayerState
+- Display media player errors to the UI in a snackbar
+- Added no poster url
 
 == Antarctica 10/7/2024
 

--- a/mobile/src/main/java/gizz/tapes/data/ApiErrorMessage.kt
+++ b/mobile/src/main/java/gizz/tapes/data/ApiErrorMessage.kt
@@ -1,0 +1,4 @@
+package gizz.tapes.data
+
+// data class instead of value class for dagger usage
+data class ApiErrorMessage(val value: String)

--- a/mobile/src/main/java/gizz/tapes/data/PlayerErrorMessage.kt
+++ b/mobile/src/main/java/gizz/tapes/data/PlayerErrorMessage.kt
@@ -1,0 +1,4 @@
+package gizz.tapes.data
+
+// data class instead of value class for dagger usage
+data class PlayerErrorMessage(val value: String)

--- a/mobile/src/main/java/gizz/tapes/di/GizzTapesModule.kt
+++ b/mobile/src/main/java/gizz/tapes/di/GizzTapesModule.kt
@@ -14,7 +14,8 @@ import gizz.tapes.R
 import gizz.tapes.api.GizzTapesApiClient
 import gizz.tapes.playback.MediaPlayerContainer
 import gizz.tapes.playback.RealMediaPlayerContainer
-import gizz.tapes.ui.ApiErrorMessage
+import gizz.tapes.data.ApiErrorMessage
+import gizz.tapes.data.PlayerErrorMessage
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
@@ -77,6 +78,14 @@ interface GizzTapesModule {
             @ApplicationContext context: Context
         ): ApiErrorMessage = ApiErrorMessage(
             context.getString(R.string.api_error_message)
+        )
+
+        @Provides
+        @Singleton
+        fun providePlayerErrorMessage(
+            @ApplicationContext context: Context
+        ): PlayerErrorMessage = PlayerErrorMessage(
+            context.getString(R.string.player_error)
         )
 
         @Provides

--- a/mobile/src/main/java/gizz/tapes/playback/DelegatingPlayerListener.kt
+++ b/mobile/src/main/java/gizz/tapes/playback/DelegatingPlayerListener.kt
@@ -36,7 +36,7 @@ class DelegatingPlayerListener(
     }
 
     override fun onPlayerError(error: PlaybackException) {
-        Timber.e(error, "onPlayerError")
+        Timber.e(error, "onPlayerError: ${error.errorCodeName}")
         delegates.forEach { it.onPlayerError(error) }
     }
 

--- a/mobile/src/main/java/gizz/tapes/ui/ApiErrorMessage.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/ApiErrorMessage.kt
@@ -1,3 +1,0 @@
-package gizz.tapes.ui
-
-data class ApiErrorMessage(val value: String)

--- a/mobile/src/main/java/gizz/tapes/ui/components/selection.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/components/selection.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -57,7 +58,7 @@ fun SelectionScreen(
         state = state,
         upClick = upClick,
         actions = actions
-    ) { value ->
+    ) { value, playerError ->
         Column {
             SelectionList(
                 Modifier.weight(1f),
@@ -67,7 +68,8 @@ fun SelectionScreen(
                 playerState = playerState,
                 onClick = onMiniPlayerClick,
                 onPauseAction = onPauseAction,
-                onPlayAction = onPlayAction
+                onPlayAction = onPlayAction,
+                playerError = playerError
             )
         }
     }

--- a/mobile/src/main/java/gizz/tapes/ui/player/FullPlayer.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/player/FullPlayer.kt
@@ -147,11 +147,11 @@ fun FullPlayer(
                     )
 
                     var sliderValue by remember {
-                        mutableFloatStateOf(playerState.currentPosition.toFloat())
+                        mutableFloatStateOf(playerState.durationInfo.currentPositionFloat)
                     }
 
-                    LaunchedEffect(playerState.currentPosition) {
-                        sliderValue = playerState.currentPosition.toFloat()
+                    LaunchedEffect(playerState.durationInfo.currentPosition) {
+                        sliderValue = playerState.durationInfo.currentPositionFloat
                     }
 
                     Slider(
@@ -162,7 +162,7 @@ fun FullPlayer(
                         onValueChangeFinished = {
                             seekTo(sliderValue.toLong())
                         },
-                        valueRange = 0f .. max(playerState.duration.toFloat(), 0f),
+                        valueRange = 0f .. max(playerState.durationInfo.duration.toFloat(), 0f),
                         modifier = Modifier.padding(horizontal = 16.dp)
                     )
 
@@ -175,13 +175,12 @@ fun FullPlayer(
                         Text(
                             text = sliderValue.toLong().formatedElapsedTime,
                             style = MaterialTheme.typography.labelSmall,
-
                         )
 
                         Spacer(modifier = Modifier.weight(1f))
 
                         Text(
-                            text = playerState.formatedDurationTime,
+                            text = playerState.durationInfo.durationTimeString,
                             style = MaterialTheme.typography.labelSmall
                         )
                     }

--- a/mobile/src/main/java/gizz/tapes/ui/player/MediaDurationInfo.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/player/MediaDurationInfo.kt
@@ -1,0 +1,13 @@
+package gizz.tapes.ui.player
+
+import gizz.tapes.util.formatedElapsedTime
+
+data class MediaDurationInfo(
+    val currentPosition: Long,
+    val duration: Long
+) {
+    val currentPositionFloat = currentPosition.toFloat()
+
+    val elapsedTimeString by lazy { currentPosition.formatedElapsedTime }
+    val durationTimeString by lazy { duration.formatedElapsedTime }
+}

--- a/mobile/src/main/java/gizz/tapes/ui/player/MiniPlayer.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/player/MiniPlayer.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import gizz.tapes.R
 import gizz.tapes.data.Title
+import gizz.tapes.ui.player.PlayerState.MediaLoaded.Error
 
 @Composable
 fun MiniPlayer(
@@ -36,12 +38,17 @@ fun MiniPlayer(
     onClick: (Title) -> Unit,
     onPauseAction: () -> Unit,
     onPlayAction: () -> Unit,
+    playerError: (PlayerError) -> Unit,
 ) {
     when (playerState) {
         is PlayerState.NoMedia -> return
         is PlayerState.MediaLoaded -> {
             val playing = playerState.isPlaying
-            val elapsedTime = playerState.formatedElapsedTime
+            val elapsedTime = playerState.durationInfo.elapsedTimeString
+
+            if (playerState is Error) {
+                playerError(playerState.playerError)
+            }
 
             Surface(
                 shadowElevation = 8.dp

--- a/mobile/src/main/java/gizz/tapes/ui/player/PlayerState.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/player/PlayerState.kt
@@ -4,21 +4,113 @@ import android.net.Uri
 import gizz.tapes.data.ShowId
 import gizz.tapes.data.Title
 
+@JvmInline
+value class PlayerError(val message: String)
+
 sealed interface PlayerState {
 
     data object NoMedia: PlayerState
 
-    data class MediaLoaded(
-        val isPlaying: Boolean,
-        val showId: ShowId,
-        val showTitle: Title,
-        val formatedElapsedTime: String,
-        val formatedDurationTime: String,
-        val duration: Long,
-        val currentPosition: Long,
-        val artworkUri: Uri?,
-        val title: String,
-        val albumTitle: String,
-        val mediaId: String,
-    ): PlayerState
+    sealed interface MediaLoaded: PlayerState {
+        val isPlaying: Boolean
+        val showId: ShowId
+        val showTitle: Title
+        val durationInfo: MediaDurationInfo
+        val artworkUri: Uri?
+        val title: String
+        val albumTitle: String
+        val mediaId: String
+
+        companion object {
+            operator fun invoke(
+                isPlaying: Boolean,
+                showId: ShowId,
+                showTitle: Title,
+                durationInfo: MediaDurationInfo,
+                artworkUri: Uri?,
+                title: String,
+                albumTitle: String,
+                mediaId: String,
+            ): MediaLoaded = when (isPlaying) {
+                true -> Playing(
+                    showId = showId,
+                    showTitle = showTitle,
+                    durationInfo = durationInfo,
+                    artworkUri = artworkUri,
+                    title = title,
+                    albumTitle = albumTitle,
+                    mediaId = mediaId
+                )
+
+                false -> Paused(
+                    showId = showId,
+                    showTitle = showTitle,
+                    durationInfo = durationInfo,
+                    artworkUri = artworkUri,
+                    title = title,
+                    albumTitle = albumTitle,
+                    mediaId = mediaId
+                )
+            }
+        }
+
+        fun copy(isPlaying: Boolean) = when (isPlaying) {
+            true -> Playing(
+                showId = showId,
+                showTitle = showTitle,
+                durationInfo = durationInfo,
+                artworkUri = artworkUri,
+                title = title,
+                albumTitle = albumTitle,
+                mediaId = mediaId
+            )
+
+            false -> Paused(
+                showId = showId,
+                showTitle = showTitle,
+                durationInfo = durationInfo,
+                artworkUri = artworkUri,
+                title = title,
+                albumTitle = albumTitle,
+                mediaId = mediaId
+            )
+        }
+
+        data class Playing(
+            override val showId: ShowId,
+            override val showTitle: Title,
+            override val durationInfo: MediaDurationInfo,
+            override val artworkUri: Uri?,
+            override val title: String,
+            override val albumTitle: String,
+            override val mediaId: String
+        ) : MediaLoaded {
+            override val isPlaying = true
+        }
+
+        data class Paused(
+            override val showId: ShowId,
+            override val showTitle: Title,
+            override val durationInfo: MediaDurationInfo,
+            override val artworkUri: Uri?,
+            override val title: String,
+            override val albumTitle: String,
+            override val mediaId: String
+        ): MediaLoaded {
+            override val isPlaying = false
+        }
+
+        data class Error(
+            val playerError: PlayerError,
+            override val showId: ShowId,
+            override val showTitle: Title,
+            override val durationInfo: MediaDurationInfo,
+            override val artworkUri: Uri?,
+            override val title: String,
+            override val albumTitle: String,
+            override val mediaId: String
+        ): MediaLoaded {
+            override val isPlaying = false
+        }
+    }
 }

--- a/mobile/src/main/java/gizz/tapes/ui/show/ShowScreen.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/show/ShowScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -54,6 +55,7 @@ import gizz.tapes.ui.components.LoadingScreen
 import gizz.tapes.data.PosterUrl
 import gizz.tapes.data.Title
 import gizz.tapes.ui.player.MiniPlayer
+import gizz.tapes.ui.player.PlayerError
 import gizz.tapes.ui.player.PlayerState
 import gizz.tapes.ui.player.PlayerState.MediaLoaded
 import gizz.tapes.ui.player.PlayerState.NoMedia
@@ -125,7 +127,7 @@ fun ShowScreen(
         state = state,
         upClick = upClick,
         actions = actions
-    ) { value ->
+    ) { value, playerError ->
         when(state) {
             is LCE.Content -> ShowListWithPlayer(
                 showData = value,
@@ -133,7 +135,8 @@ fun ShowScreen(
                 onRowClick = onRowClick,
                 onPauseAction = onPauseAction,
                 onPlayAction = onPlayAction,
-                playerState = playerState
+                playerState = playerState,
+                playerError = playerError
             )
             is LCE.Error -> ErrorScreen(state.userDisplayedMessage)
             LCE.Loading -> LoadingScreen()
@@ -149,6 +152,7 @@ fun ShowListWithPlayer(
     onMiniPlayerClick: (Title) -> Unit,
     onPauseAction: () -> Unit,
     onPlayAction: () -> Unit,
+    playerError: (PlayerError) -> Unit,
 ) {
     val (currentlyPlayingMediaId, playing) = when(playerState) {
         is MediaLoaded -> playerState.mediaId to playerState.isPlaying
@@ -176,7 +180,8 @@ fun ShowListWithPlayer(
             onClick = onMiniPlayerClick,
             playerState = playerState,
             onPauseAction = onPauseAction,
-            onPlayAction = onPlayAction
+            onPlayAction = onPlayAction,
+            playerError = playerError
         )
     }
 }

--- a/mobile/src/main/java/gizz/tapes/ui/show/ShowSelectionViewModel.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/show/ShowSelectionViewModel.kt
@@ -8,7 +8,7 @@ import gizz.tapes.api.GizzTapesApiClient
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import gizz.tapes.ui.ApiErrorMessage
+import gizz.tapes.data.ApiErrorMessage
 import gizz.tapes.data.FullShowTitle
 import gizz.tapes.data.PosterUrl
 import gizz.tapes.data.ShowId

--- a/mobile/src/main/java/gizz/tapes/ui/show/ShowViewModel.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/show/ShowViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import gizz.tapes.playback.MediaPlayerContainer
-import gizz.tapes.ui.ApiErrorMessage
+import gizz.tapes.data.ApiErrorMessage
 import gizz.tapes.data.PosterUrl
 import gizz.tapes.data.Title
 import gizz.tapes.ui.show.ShowScreenData.Track

--- a/mobile/src/main/java/gizz/tapes/ui/year/YearSelectionViewModel.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/year/YearSelectionViewModel.kt
@@ -7,7 +7,7 @@ import gizz.tapes.api.GizzTapesApiClient
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import gizz.tapes.ui.ApiErrorMessage
+import gizz.tapes.data.ApiErrorMessage
 import gizz.tapes.data.PosterUrl
 import gizz.tapes.data.Year
 import gizz.tapes.util.LCE

--- a/mobile/src/main/java/gizz/tapes/util/media.kt
+++ b/mobile/src/main/java/gizz/tapes/util/media.kt
@@ -7,7 +7,6 @@ import gizz.tapes.data.ShowId
 import gizz.tapes.data.Title
 
 val Long.formatedElapsedTime: String get() = DateUtils.formatElapsedTime(this / 1000L)
-val Player.formatedElapsedTime: String get() = DateUtils.formatElapsedTime(currentPosition / 1000L)
 val MediaItem?.title: String get() = this?.mediaMetadata?.title?.toString() ?: "--"
 
 /** Must be called on metadata with extras **/

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="play">Play</string>
 
     <string name="api_error_message">There was an error getting data from kglw.net. We are continually attempting to get data, and this page will automatically update when we get a connection, in the meantime please check your network connection.</string>
+
+    <string name="player_error">There was an issue loading the current track. Try a different track or maybe archive.org is having issues.</string>
 </resources>

--- a/mobile/src/test/java/gizz/tapes/test-data.kt
+++ b/mobile/src/test/java/gizz/tapes/test-data.kt
@@ -16,6 +16,7 @@ import gizz.tapes.data.ShowId
 import gizz.tapes.data.Subtitle
 import gizz.tapes.data.Title
 import gizz.tapes.data.Year
+import gizz.tapes.ui.player.MediaDurationInfo
 import gizz.tapes.ui.player.PlayerState
 import gizz.tapes.ui.show.ShowScreenData
 import gizz.tapes.ui.show.ShowScreenData.Track
@@ -48,10 +49,10 @@ val noShowPlayerState = PlayerState.NoMedia
 
 val showingPlayerState = PlayerState.MediaLoaded(
     isPlaying = true,
-    formatedDurationTime = "13:37",
-    formatedElapsedTime = "1:23",
-    duration = 7.minutes.inWholeMilliseconds,
-    currentPosition = 1.minutes.inWholeMilliseconds,
+    durationInfo = MediaDurationInfo(
+        currentPosition = 1.minutes.inWholeMilliseconds,
+        duration = 7.minutes.inWholeMilliseconds
+    ),
     showId = ShowId("showId"),
     artworkUri = "https://kglw.net/i/poster-art-1699403482.jpeg".toUri(),
     albumTitle = "2024-09-11 : Edgefield Amphitheater - Troutdale, OR, USA",
@@ -75,17 +76,17 @@ val yearData = LCE.Content(
         YearSelectionData(
             year = Year("2022"),
             showCount = 5,
-            randomShowPoster = null
+            randomShowPoster = PosterUrl(null)
         ),
         YearSelectionData(
             year = Year("2021"),
             showCount = 32,
-            randomShowPoster = null
+            randomShowPoster = PosterUrl(null)
         ),
         YearSelectionData(
             year = Year("2020"),
             showCount = 32,
-            randomShowPoster = null
+            randomShowPoster = PosterUrl(null)
         )
     )
 )

--- a/mobile/src/test/java/gizz/tapes/ui/player/FullPlayerTest.kt
+++ b/mobile/src/test/java/gizz/tapes/ui/player/FullPlayerTest.kt
@@ -20,7 +20,7 @@ class FullPlayerTest : PaparazziTest() {
 
     @Test
     fun paused() {
-        snapshot(showingPlayerState.copy(isPlaying = false))
+        snapshot(showingPlayerState)
     }
 
     private fun snapshot(state: PlayerState) {

--- a/mobile/src/test/java/gizz/tapes/ui/player/MiniPlayerTest.kt
+++ b/mobile/src/test/java/gizz/tapes/ui/player/MiniPlayerTest.kt
@@ -37,7 +37,8 @@ class MiniPlayerTest : PaparazziTest() {
                     playerState = state,
                     onClick = {},
                     onPlayAction = {},
-                    onPauseAction = {}
+                    onPauseAction = {},
+                    playerError = {}
                 )
             }
         }

--- a/mobile/src/test/java/gizz/tapes/ui/player/PlayerViewModelTest.kt
+++ b/mobile/src/test/java/gizz/tapes/ui/player/PlayerViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import com.google.common.truth.Truth.assertThat
 import gizz.tapes.MainDispatcherRule
+import gizz.tapes.data.PlayerErrorMessage
 import gizz.tapes.data.Title
 import gizz.tapes.mediaItem
 import gizz.tapes.playback.MediaPlayerContainer
@@ -22,7 +23,8 @@ class PlayerViewModelTest {
     fun `title should be null when one is not in savedStateHandle`() {
         val classUnderTest = PlayerViewModel(
             mediaPlayerContainer = unimportantMediaPlayerContainer,
-            savedStateHandle = SavedStateHandle()
+            savedStateHandle = SavedStateHandle(),
+            playerErrorMessage = PlayerErrorMessage("There was an error!")
         )
 
         assertThat(classUnderTest.title).isNull()
@@ -34,7 +36,8 @@ class PlayerViewModelTest {
             mediaPlayerContainer = unimportantMediaPlayerContainer,
             savedStateHandle = SavedStateHandle(
                 initialState = mapOf("title" to "Alpine Valley".encodeUtf8().base64Url())
-            )
+            ),
+            playerErrorMessage = PlayerErrorMessage("There was an error!")
         )
 
         assertThat(classUnderTest.title).isEqualTo(


### PR DESCRIPTION
Allows the player to go into the error state and update the UI to notify the user. This is helpful when archive.org is down.