### PR TITLE
Remove Dependency Info From APK and Bundle

### DIFF
--- a/mobile/mobile.gradle.kts
+++ b/mobile/mobile.gradle.kts
@@ -86,7 +86,6 @@ android {
         create("foss") {
             applicationIdSuffix = ".foss"
             dimension = "version"
-            versionNameSuffix = "-foss"
             (this as ExtensionAware).configure<CrashlyticsExtension> {
                 mappingFileUploadEnabled = false
             }
@@ -112,6 +111,11 @@ android {
         renderScript = false
         resValues = false
         shaders = false
+    }
+
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
     }
 }
 


### PR DESCRIPTION
This is required for publishing to f-droid.