### PR TITLE
Fixs Playing First Song when Tapping Other Rows

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,10 @@
 
 == Dawn of Eternal Night
 
+- Fix system ui icon being same color as app background
+- Fix issue when playing a new show would always play the first song
+even when taping other songs in the show.
+
 == Converge-Patch1 2024-11-18
 
 - Removes dependenciesInfo from bundle and apk for f-droid release

--- a/mobile/src/main/java/gizz/tapes/ui/show/ShowScreen.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/show/ShowScreen.kt
@@ -86,6 +86,7 @@ fun ShowScreen(
                 firstLoad = false
                 val content = checkNotNull(showState.contentOrNull())
                 content.removeOldMediaItemsAndAddNew()
+                playerViewModel.seekTo(index, 0)
                 playerViewModel.play()
             } else {
                 when (val ps = playerState) {


### PR DESCRIPTION
Fixes and issue on the show screen where tapping any row would always play the first song.

Fixes #34