### PR TITLE
Add Null Checks Around Media Bundle

### DIFF
--- a/mobile/src/main/java/gizz/tapes/ui/player/PlayerViewModel.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/player/PlayerViewModel.kt
@@ -12,12 +12,14 @@ import gizz.tapes.data.PlayerErrorMessage
 import gizz.tapes.data.Title
 import gizz.tapes.playback.MediaPlayerContainer
 import gizz.tapes.ui.player.PlayerState.NoMedia
+import gizz.tapes.util.MediaItemWrapper
 import gizz.tapes.util.mediaExtras
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @UnstableApi
@@ -115,7 +117,13 @@ class PlayerViewModel @Inject constructor(
             cmi.mediaId.isEmpty() -> NoMedia
             else -> {
                 val metadata = cmi.mediaMetadata
-                val (showId, venueName) = cmi.mediaExtras
+                val (showId, venueName) = cmi.mediaExtras ?: run {
+                    Timber.w(
+                        "Current media item does not have required extras: %s",
+                        MediaItemWrapper(cmi)
+                    )
+                    return NoMedia
+                }
 
                 if (playerError == null) {
                     PlayerState.MediaLoaded(

--- a/mobile/src/main/java/gizz/tapes/util/media.kt
+++ b/mobile/src/main/java/gizz/tapes/util/media.kt
@@ -10,7 +10,7 @@ val Long.formatedElapsedTime: String get() = DateUtils.formatElapsedTime(max(thi
 val MediaItem?.title: String get() = this?.mediaMetadata?.title?.toString() ?: "--"
 
 /** Must be called on metadata with extras **/
-val MediaItem.mediaExtras: Pair<ShowId, Title> get() = mediaMetadata.extras!!.toShowInfo()
+val MediaItem.mediaExtras: Pair<ShowId, Title>? get() = mediaMetadata.extras?.toShowInfo()
 
 fun MediaItem.toReadableString() = """
     mediaId=${this.mediaId}


### PR DESCRIPTION
Ads null checks and logs around the media bundle to prevent NPEs. Fixes an issue reported by the android pre-release report.