### PR TITLE
Add Loading Indicators when Player is Loading

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,7 @@
 - Bug fixes and Performance
 - Fixed Image Caching
 - Sorting for shows and years
+- Show media loading in media player ui
 
 == Dawn of Eternal Night 2024-12-08
 

--- a/mobile/src/main/java/gizz/tapes/ui/player/FullPlayer.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/player/FullPlayer.kt
@@ -2,6 +2,7 @@
 
 package gizz.tapes.ui.player
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,6 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
@@ -155,17 +157,38 @@ fun FullPlayer(
                         sliderValue = playerState.durationInfo.currentPositionFloat
                     }
 
-                    Slider(
-                        value = sliderValue,
-                        onValueChange = {
-                            sliderValue = it
+                    AnimatedContent(
+                        targetState = playerState,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        contentKey = { current ->
+                            when(current) {
+                                is PlayerState.MediaLoaded.Loading -> "Loading"
+                                else -> "Media Loaded"
+                            }
                         },
-                        onValueChangeFinished = {
-                            seekTo(sliderValue.toLong())
-                        },
-                        valueRange = 0f .. max(playerState.durationInfo.duration.toFloat(), 0f),
-                        modifier = Modifier.padding(horizontal = 16.dp)
-                    )
+                        label = "Full Player Loading State"
+                    ) { s ->
+                        when (s) {
+                            is PlayerState.MediaLoaded.Loading -> LinearProgressIndicator(
+                                modifier = Modifier.fillMaxWidth()
+                                    .padding(vertical = 8.dp),
+                            )
+
+                            else -> Slider(
+                                value = sliderValue,
+                                onValueChange = {
+                                    sliderValue = it
+                                },
+                                onValueChangeFinished = {
+                                    seekTo(sliderValue.toLong())
+                                },
+                                valueRange = 0f..max(
+                                    playerState.durationInfo.duration.toFloat(),
+                                    0f
+                                )
+                            )
+                        }
+                    }
 
                     Row(
                         modifier = Modifier

--- a/mobile/src/main/java/gizz/tapes/ui/player/MiniPlayer.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/player/MiniPlayer.kt
@@ -1,12 +1,17 @@
 package gizz.tapes.ui.player
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -16,6 +21,7 @@ import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -26,11 +32,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import gizz.tapes.R
+import gizz.tapes.data.ShowId
 import gizz.tapes.data.Title
 import gizz.tapes.ui.player.PlayerState.MediaLoaded.Error
+import gizz.tapes.ui.player.PlayerState.MediaLoaded.Loading
 
 @Composable
 fun MiniPlayer(
@@ -53,77 +62,118 @@ fun MiniPlayer(
             Surface(
                 shadowElevation = 8.dp
             ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp)
-                        .shadow(2.dp)
-                        .background(MaterialTheme.colorScheme.primaryContainer)
-                        .clickable {
-                            onClick(Title(playerState.albumTitle))
-                        },
-                ) {
-
-                    AsyncImage(
-                        model = playerState.artworkUri,
-                        contentDescription = null,
-                        modifier = Modifier.size(56.dp),
-                        contentScale = ContentScale.Crop
-                    )
-
-                    Column(
+                Column {
+                    Row(
                         modifier = Modifier
-                            .padding(8.dp)
-                            .weight(1f)
+                            .fillMaxWidth()
+                            .height(56.dp)
+                            .shadow(2.dp)
+                            .background(MaterialTheme.colorScheme.primaryContainer)
+                            .clickable {
+                                onClick(Title(playerState.albumTitle))
+                            },
                     ) {
 
-                        Text(
-                            text = playerState.title,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.basicMarquee(
-                                iterations = Int.MAX_VALUE
-                            ),
-                            maxLines = 1
+                        AsyncImage(
+                            model = playerState.artworkUri,
+                            contentDescription = null,
+                            modifier = Modifier.size(56.dp),
+                            contentScale = ContentScale.Crop
                         )
-                        Text(
-                            text = playerState.albumTitle,
-                            style = MaterialTheme.typography.bodySmall,
-                            maxLines = 1
-                        )
-                    }
 
-                    Box(modifier = Modifier.fillMaxHeight()) {
-                        Text(
-                            text = elapsedTime,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.align(Center)
-                        )
-                    }
+                        Column(
+                            modifier = Modifier
+                                .padding(8.dp)
+                                .weight(1f)
+                        ) {
 
-                    IconButton(
-                        onClick = {
-                            if (playing) {
-                                onPauseAction()
-                            } else {
-                                onPlayAction()
+                            Text(
+                                text = playerState.title,
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.basicMarquee(
+                                    iterations = Int.MAX_VALUE
+                                ),
+                                maxLines = 1
+                            )
+                            Text(
+                                text = playerState.albumTitle,
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 1
+                            )
+                        }
+
+                        Box(modifier = Modifier.fillMaxHeight()) {
+                            Text(
+                                text = elapsedTime,
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.align(Center)
+                            )
+                        }
+
+                        IconButton(
+                            onClick = {
+                                if (playing) {
+                                    onPauseAction()
+                                } else {
+                                    onPlayAction()
+                                }
                             }
-                        }
-                    ) {
-                        val (imageVector, contentDescription) = if (playing) {
-                            Icons.Default.Pause to stringResource(R.string.pause)
-                        } else {
-                            Icons.Default.PlayArrow to stringResource(R.string.pause)
-                        }
+                        ) {
+                            val (imageVector, contentDescription) = if (playing) {
+                                Icons.Default.Pause to stringResource(R.string.pause)
+                            } else {
+                                Icons.Default.PlayArrow to stringResource(R.string.pause)
+                            }
 
-                        Icon(
-                            imageVector = imageVector,
-                            contentDescription = contentDescription,
-                            modifier = Modifier.align(CenterVertically)
+                            Icon(
+                                imageVector = imageVector,
+                                contentDescription = contentDescription,
+                                modifier = Modifier.align(CenterVertically)
+                            )
+                        }
+                    }
+
+                    val shouldDisplay = playerState is Loading
+                    AnimatedVisibility(
+                        visible = shouldDisplay,
+                        enter = fadeIn(),
+                        exit = fadeOut()
+                    ) {
+                        LinearProgressIndicator(
+                            modifier = Modifier.fillMaxWidth(),
                         )
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+@Preview
+fun MiniPlayerPreview() {
+
+    val state = Loading(
+        showId = ShowId("showId"),
+        showTitle = Title("Show Title"),
+        durationInfo = MediaDurationInfo(currentPosition = 0, duration = 1000),
+        artworkUri = null,
+        title = "Title",
+        albumTitle = "AlbumTitle",
+        mediaId = "mediaId",
+    )
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+            .height(64.dp)
+    ) {
+        MiniPlayer(
+            playerState = state,
+            onClick = {},
+            onPlayAction = {},
+            onPauseAction = {},
+            playerError = {}
+        )
     }
 }
 


### PR DESCRIPTION
When the media player is loading content, we emit a new loading state that will now show indicators on the mini and full players in order to display to the user that something is going on in the background.