### PR TITLE
Highlight background of playing song

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,9 @@
 
 == Gaia
 
+- Fixed bug where the currently playing track wasn't shown as playing in the show screen
+- Highlight the background of the currently playing track on the show screen
+
 == Fishing For Fishies 2025-03-02
 
 - Save player state, app restarts will no longer effect where you were left off in a show.

--- a/mobile/src/main/java/gizz/tapes/ui/show/ShowScreen.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/show/ShowScreen.kt
@@ -426,7 +426,7 @@ fun TrackRow(
         modifier = Modifier
             .padding(horizontal = 4.dp)
             .clip(RoundedCornerShape(8.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .background(if (playing) MaterialTheme.colorScheme.surfaceContainerHighest else MaterialTheme.colorScheme.surfaceContainer)
             .fillMaxWidth()
             .requiredHeight(96.dp)
             .height(IntrinsicSize.Max)

--- a/mobile/src/main/java/gizz/tapes/ui/show/ShowScreenState.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/show/ShowScreenState.kt
@@ -1,6 +1,7 @@
 package gizz.tapes.ui.show
 
 import arrow.core.NonEmptyList
+import gizz.tapes.data.MediaId.TrackId
 import gizz.tapes.data.PosterUrl
 
 data class ShowScreenState(

--- a/mobile/src/main/java/gizz/tapes/ui/show/ShowViewModel.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/show/ShowViewModel.kt
@@ -143,7 +143,7 @@ class ShowViewModel @Inject constructor(
                     },
                     tracks = recording.files.map {
                         Track(
-                            id = TrackId(it.filename),
+                            id = MediaId.TrackId(recording = recording, show = show, file = it),
                             title = TrackTitle(it.title),
                             duration = TrackDuration(it.length)
                         )

--- a/mobile/src/main/java/gizz/tapes/ui/show/TrackId.kt
+++ b/mobile/src/main/java/gizz/tapes/ui/show/TrackId.kt
@@ -1,4 +1,0 @@
-package gizz.tapes.ui.show
-
-@JvmInline
-value class TrackId(val id: String)

--- a/mobile/src/test/java/gizz/tapes/test-data.kt
+++ b/mobile/src/test/java/gizz/tapes/test-data.kt
@@ -11,6 +11,7 @@ import gizz.tapes.api.data.PartialShowData
 import gizz.tapes.api.data.Recording
 import gizz.tapes.api.data.Show
 import gizz.tapes.data.FullShowTitle
+import gizz.tapes.data.MediaId
 import gizz.tapes.data.PosterUrl
 import gizz.tapes.data.ShowId
 import gizz.tapes.data.Subtitle
@@ -24,7 +25,6 @@ import gizz.tapes.ui.show.RecordingId
 import gizz.tapes.ui.show.ShowScreenState
 import gizz.tapes.ui.show.ShowScreenState.Track
 import gizz.tapes.ui.show.TrackDuration
-import gizz.tapes.ui.show.TrackId
 import gizz.tapes.ui.show.TrackTitle
 import gizz.tapes.ui.year.YearSelectionData
 import gizz.tapes.util.LCE
@@ -309,7 +309,11 @@ val showContent = LCE.Content(
         showPosterUrl = PosterUrl("https://kglw.net/i/poster-art-1699403482.jpeg"),
         tracks = show.recordings.first().files.map {
             Track(
-                id = TrackId(it.filename),
+                id = MediaId.TrackId(
+                    show = show,
+                    recording = show.recordings.first(),
+                    file = it
+                ),
                 title = TrackTitle(it.title),
                 duration = TrackDuration(it.length)
             )


### PR DESCRIPTION
Also fixes issue with ids not being correct for finding the currently playing song that was introduced in the previous release.

Ticket: https://github.com/Ghost-Applications/gizz-tapes/issues/36