### PR TITLE
refactor(error-handling): simplify LCE error state and error screen

### DIFF
--- a/androidApp/src/main/kotlin/gizz/tapes/MainActivity.kt
+++ b/androidApp/src/main/kotlin/gizz/tapes/MainActivity.kt
@@ -15,7 +15,7 @@ import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
 import gizz.tapes.ui.components.CastButton
 
 @Inject
-@ActivityKey(MainActivity::class)
+@ActivityKey
 @ContributesIntoMap(AppScope::class, binding<Activity>())
 class MainActivity(
     private val metroViewModelFactory: MetroViewModelFactory,

--- a/androidApp/src/main/kotlin/gizz/tapes/PlaybackService.kt
+++ b/androidApp/src/main/kotlin/gizz/tapes/PlaybackService.kt
@@ -53,7 +53,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @Inject
 @UnstableApi
-@ServiceKey(PlaybackService::class)
+@ServiceKey
 @ContributesIntoMap(AppScope::class, binding<Service>())
 class PlaybackService(
     private val playerFactory: PlayerFactory,

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="pause">Pause</string>
     <string name="play">Play</string>
 
-    <string name="api_error_message">There was an error getting data from kglw.net. We are continually attempting to get data, and this page will automatically update when we get a connection, in the meantime please check your network connection.</string>
+    <string name="api_error_message">Looks like something went wrong. Hang tight while we try to reconnect.</string>
     <string name="player_error">There was an issue loading the current track. Try a different track or maybe archive.org is having issues.</string>
 
     <string name="about">About</string>

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/AppGraph.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/AppGraph.kt
@@ -10,8 +10,6 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metrox.viewmodel.ViewModelGraph
 import gizz.tapes.api.GizzTapesApiClient
-import gizz.tapes.api.GizzTapesApiClient.Companion.invoke
-import gizz.tapes.data.ApiErrorMessage
 import gizz.tapes.data.Settings
 import gizz.tapes.data.SettingsSerializer
 import gizz.tapes.playback.CurrentlyPlayingSaver
@@ -60,11 +58,6 @@ interface AppGraph : ViewModelGraph {
     @SingleIn(AppScope::class)
     fun provideCurrentlyPlayingSaver(dataStore: DataStore<StoredMediaSession>): CurrentlyPlayingSaver =
         CurrentlyPlayingSaver(dataStore)
-
-    @Provides
-    @SingleIn(AppScope::class)
-    fun provideApiErrorMessage(): ApiErrorMessage =
-        ApiErrorMessage("Unable to load data. Please check your connection.")
 
     @Provides
     @SingleIn(AppScope::class)

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/data/ApiErrorMessage.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/data/ApiErrorMessage.kt
@@ -1,3 +1,0 @@
-package gizz.tapes.data
-
-data class ApiErrorMessage(val value: String)

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/components/GizzScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/components/GizzScaffold.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun <T> GizzScaffold(
     title: Title,
-    state: LCE<T, Any>,
+    state: LCE<T, Throwable>,
     navigateUp: (NavigateUp)?,
     actions: @Composable RowScope.() -> Unit,
     content: @Composable (value: T, playerError: (PlayerError) -> Unit) -> Unit
@@ -68,7 +68,7 @@ fun <T> GizzScaffold(
                 .fillMaxSize()
         ) { s ->
             when (s) {
-                is LCE.Error -> ErrorScreen(s.userDisplayedMessage)
+                is LCE.Error -> ErrorScreen(error = s.error)
                 is LCE.Content -> content(s.value) {
                     scope.launch {
                         snackbarHostState.showSnackbar(

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/components/UtilityScreens.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/components/UtilityScreens.kt
@@ -1,16 +1,28 @@
 package gizz.tapes.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import gizz_tapes.composeapp.generated.resources.Res
+import gizz_tapes.composeapp.generated.resources.api_error_message
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun LoadingScreen(modifier: Modifier = Modifier) {
@@ -23,15 +35,48 @@ fun LoadingScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun ErrorScreen(message: String, modifier: Modifier = Modifier) {
+fun ErrorScreen(
+    error: Throwable,
+    modifier: Modifier = Modifier,
+    message: String = stringResource(Res.string.api_error_message)
+) {
+    var clickCount by remember { mutableStateOf(0) }
+
     Box(
         modifier = modifier.fillMaxSize().padding(16.dp),
         contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = message,
-            style = MaterialTheme.typography.bodyLarge,
-            textAlign = TextAlign.Center
-        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.clickable {
+                clickCount++
+            }
+        ) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            CircularProgressIndicator()
+
+            if (clickCount > 5) {
+                Text(
+                    text = error.stackTraceToString()
+                )
+            }
+        }
     }
+}
+
+@Preview
+@Composable
+private fun LoadingScreenPreview() {
+    LoadingScreen()
+}
+
+@Preview
+@Composable
+private fun ErrorScreenPreview() {
+    ErrorScreen(error = Exception("Test"))
 }

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/components/selection.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/components/selection.kt
@@ -49,7 +49,7 @@ data class SelectionData(
 @Composable
 fun SelectionScreen(
     title: Title = Title(stringResource(Res.string.app_name)),
-    state: LCE<List<SelectionData>, Any>,
+    state: LCE<List<SelectionData>, Throwable>,
     playerState: PlayerState,
     onPauseAction: () -> Unit,
     onPlayAction: () -> Unit,

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/player/PlayerViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/player/PlayerViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 @Inject
 @ContributesIntoMap(AppScope::class)
-@ViewModelKey(PlayerViewModel::class)
+@ViewModelKey
 class PlayerViewModel(
     private val mediaPlayer: GizzMediaPlayer,
 ) : ViewModel() {

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/selection/ShowSelectionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/selection/ShowSelectionViewModel.kt
@@ -16,7 +16,6 @@ import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
 import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import gizz.tapes.api.GizzTapesApiClient
-import gizz.tapes.data.ApiErrorMessage
 import gizz.tapes.data.FullShowTitle
 import gizz.tapes.data.PosterUrl
 import gizz.tapes.data.Settings
@@ -42,7 +41,6 @@ import kotlinx.coroutines.launch
 @AssistedInject
 class ShowSelectionViewModel(
     private val apiClient: GizzTapesApiClient,
-    private val apiErrorMessage: ApiErrorMessage,
     private val settingsDataStore: DataStore<Settings>,
     @Assisted savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -92,7 +90,7 @@ class ShowSelectionViewModel(
             },
             onErrorAfter3SecondsAction = { error ->
                 logger.d(error) { "Error retrieving shows" }
-                emit(LCE.Error(userDisplayedMessage = apiErrorMessage.value, error = error))
+                emit(LCE.Error(error = error))
             }
         )
         emit(state)

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/settings/SettingsViewModel.kt
@@ -20,14 +20,14 @@ import kotlinx.coroutines.launch
 
 @Inject
 @ContributesIntoMap(AppScope::class)
-@ViewModelKey(SettingsViewModel::class)
+@ViewModelKey
 class SettingsViewModel(
     private val dataStore: DataStore<Settings>,
 ) : ViewModel() {
 
     val settingsState: StateFlow<LCE<SettingsScreenState, Nothing>> = loadSettings().stateIn(
         scope = viewModelScope,
-        started = SharingStarted.Companion.WhileSubscribed(),
+        started = SharingStarted.WhileSubscribed(),
         initialValue = LCE.Loading
     )
 

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/show/ShowScreen.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/show/ShowScreen.kt
@@ -151,7 +151,7 @@ fun ShowScreen(
                 Box(modifier = Modifier.weight(1f)) {
                     when (showState) {
                         LCE.Loading -> LoadingScreen()
-                        is LCE.Error -> ErrorScreen(showState.userDisplayedMessage)
+                        is LCE.Error -> ErrorScreen(error = showState.error)
                         is LCE.Content -> ShowContent(
                             state = showState.value,
                             playerState = playerState,

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/show/ShowViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/show/ShowViewModel.kt
@@ -18,7 +18,6 @@ import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
 import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import gizz.tapes.api.GizzTapesApiClient
 import gizz.tapes.api.data.Show
-import gizz.tapes.data.ApiErrorMessage
 import gizz.tapes.data.FullShowTitle
 import gizz.tapes.data.PosterUrl
 import gizz.tapes.data.RecordingData
@@ -49,7 +48,6 @@ import kotlinx.coroutines.launch
 class ShowViewModel(
     private val apiClient: GizzTapesApiClient,
     private val mediaPlayer: GizzMediaPlayer,
-    private val apiErrorMessage: ApiErrorMessage,
     private val datastore: DataStore<Settings>,
     @Assisted savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -83,7 +81,7 @@ class ShowViewModel(
             onErrorAfter3SecondsAction = { error ->
                 logger.d(error) { "Error retrieving show" }
                 errorFlow.emit(
-                    LCE.Error(userDisplayedMessage = apiErrorMessage.value, error = error)
+                    LCE.Error(error = error)
                 )
             }
         )

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/years/YearSelectionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/years/YearSelectionViewModel.kt
@@ -9,7 +9,6 @@ import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import gizz.tapes.api.GizzTapesApiClient
-import gizz.tapes.data.ApiErrorMessage
 import gizz.tapes.data.PosterUrl
 import gizz.tapes.data.Settings
 import gizz.tapes.data.SortOrder
@@ -28,10 +27,9 @@ import kotlinx.coroutines.launch
 
 @Inject
 @ContributesIntoMap(AppScope::class)
-@ViewModelKey(YearSelectionViewModel::class)
+@ViewModelKey
 class YearSelectionViewModel(
     private val apiClient: GizzTapesApiClient,
-    private val apiErrorMessage: ApiErrorMessage,
     private val settingsDataStore: DataStore<Settings>
 ) : ViewModel() {
 
@@ -67,7 +65,7 @@ class YearSelectionViewModel(
                                 YearSelectionData(
                                     year = Year(year),
                                     showCount = shows.count(),
-                                    randomShowPoster = PosterUrl.Companion(shows.random().posterUrl)
+                                    randomShowPoster = PosterUrl(shows.random().posterUrl)
                                 )
                             }
                             .reversed()
@@ -76,10 +74,7 @@ class YearSelectionViewModel(
                 onErrorAfter3SecondsAction = { error ->
                     logger.d(error) { "Error loading years." }
                     emit(
-                        LCE.Error(
-                            userDisplayedMessage = apiErrorMessage.value,
-                            error = error
-                        )
+                        LCE.Error(error = error)
                     )
                 }
             )

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/util/LCE.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/util/LCE.kt
@@ -5,7 +5,7 @@ package gizz.tapes.util
 sealed interface LCE<out CONTENT, out ERROR> {
     data object Loading : LCE<Nothing, Nothing>
     data class Content<out C>(val value: C) : LCE<C, Nothing>
-    data class Error<E>(val userDisplayedMessage: String, val error: E) : LCE<Nothing, E>
+    data class Error<E>(val error: E) : LCE<Nothing, E>
 }
 
 fun <CONTENT, E> LCE<CONTENT, E>.contentOrNull(): CONTENT? = when (this) {

--- a/composeApp/src/commonTest/kotlin/gizz/tapes/util/LCETest.kt
+++ b/composeApp/src/commonTest/kotlin/gizz/tapes/util/LCETest.kt
@@ -20,7 +20,7 @@ class LCETest {
 
     @Test
     fun `contentOrNull returns null for Error`() {
-        assertNull(LCE.Error("oops", Exception()).contentOrNull())
+        assertNull(LCE.Error(Exception()).contentOrNull())
     }
 
     // onContent
@@ -42,7 +42,7 @@ class LCETest {
     @Test
     fun `onContent does not invoke action for Error`() {
         var called = false
-        LCE.Error("oops", Exception()).onContent { called = true }
+        LCE.Error(Exception()).onContent { called = true }
         assertEquals(false, called)
     }
 
@@ -61,7 +61,7 @@ class LCETest {
 
     @Test
     fun `map passes through Error`() {
-        val error = LCE.Error("oops", Exception())
+        val error = LCE.Error(Exception())
         val result = error.map { "transformed" }
         assertEquals(error, result)
     }
@@ -82,7 +82,7 @@ class LCETest {
 
     @Test
     fun `mapCollection passes through Error`() {
-        val error: LCE.Error<Exception> = LCE.Error("oops", Exception())
+        val error: LCE.Error<Exception> = LCE.Error(Exception())
         val result = error.mapCollection<String, String, Exception> { "x" }
         assertEquals(error, result)
     }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -17,12 +17,16 @@ formatting:
     active: false
 
 style:
+  UnusedPrivateMember:
+    active: true
+    # Preview composables are used by the IDE, not by code
+    ignoreAnnotated: ['Preview']
   MagicNumber:
     active: false
   ReturnCount:
     active: false
   WildcardImport:
-    active: true
+    active: false
   MaxLineLength:
     active: false
   # SelectionData has 4 fields — destructuring all 4 is fine

--- a/justfile
+++ b/justfile
@@ -4,8 +4,14 @@ set shell := ['bash', '-c']
 test:
     ./gradlew test allTests runIntegrationTests detekt
 
+detekt:
+    ./gradlew detekt
+
 build:
     ./gradlew build bundle
+
+build-debug:
+    ./gradlew assembleFullDebug
 
 release:
     bundle exe fastlane release


### PR DESCRIPTION
Removed the ApiErrorMessage indirection and userDisplayedMessage field from LCE.Error. ErrorScreen now owns its user-facing message via string resources and accepts a Throwable directly. A hidden tap gesture (5+ taps) reveals the stack trace for debugging. All ViewModels updated to drop the ApiErrorMessage dependency.