### PR TITLE
Fix Show notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           GIZZ_TAPES_ENCODED_KEY: ${{ secrets.GIZZ_TAPES_ENCODED_KEY }}
       - name: Build and test
         run: >
-          ./gradlew :androidApp:test :androidApp:assemble :androidApp:bundleRelease
+          ./gradlew test allTests :androidApp:assemble :androidApp:bundleRelease
           -Dorg.gradle.jvmargs="-Xmx4G -Xms1G -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
         env:
           GIZZ_TAPES_KEYSTORE_PASSWORD: ${{ secrets.GIZZ_TAPES_KEYSTORE_PASSWORD }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,7 @@
 - Fix App Icon Not Loading
 - Updated UI to new layout. Includes today is gizztory, venues, and search
 - added themed icon for Android 13+
+- Fix html rendering in show notes
 
 == JOJAM 2026-04-28
 

--- a/composeApp/composeApp.gradle.kts
+++ b/composeApp/composeApp.gradle.kts
@@ -76,6 +76,8 @@ kotlin {
             implementation(libs.arrow.resilience)
             implementation(libs.arrow.fx)
 
+            implementation(libs.html.text)
+
             api(libs.metro.viewmodel)
         }
 

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/ui/show/ShowScreen.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/ui/show/ShowScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import de.charlex.compose.htmltext.material3.HtmlText
 import dev.zacsweers.metrox.viewmodel.assistedMetroViewModel
 import dev.zacsweers.metrox.viewmodel.metroViewModel
 import gizz.tapes.GizzTapesTheme
@@ -367,7 +368,10 @@ private fun ShowMetadata(recordingData: RecordingData) {
             .padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
         recordingData.notes?.let {
-            Text(it, style = MaterialTheme.typography.bodySmall)
+            HtmlText(
+                text = it,
+                style = MaterialTheme.typography.bodySmall
+            )
             Spacer(Modifier.height(4.dp))
         }
         recordingData.taper?.let {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,8 @@ detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", 
 
 truth = "com.google.truth:truth:1.4.5"
 
+html-text = "de.charlex.compose:html-text-material3:3.0.0-beta02"
+
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version = "1.9.0" }


### PR DESCRIPTION
Uses HtmlText to render show notes allowing for simple html to be displayed. This fixes issues with links, bold, and italics showing the html rather than rendering.