### PR TITLE
Fix Navigation Crashes

### DIFF
--- a/composeApp/src/commonMain/kotlin/gizz/tapes/data/FullShowTitle.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/data/FullShowTitle.kt
@@ -5,6 +5,8 @@ import androidx.savedstate.SavedState
 import androidx.savedstate.read
 import androidx.savedstate.write
 import gizz.tapes.util.toAlbumFormat
+import io.ktor.http.decodeURLQueryComponent
+import io.ktor.http.encodeURLPath
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -20,12 +22,15 @@ data class FullShowTitle(
         val navType = object : NavType<FullShowTitle>(isNullableAllowed = false) {
             override fun get(bundle: SavedState, key: String): FullShowTitle =
                 Json.decodeFromString(checkNotNull(bundle.read { getString(key) }))
+
             override fun put(bundle: SavedState, key: String, value: FullShowTitle) =
                 bundle.write { putString(key, Json.encodeToString(value)) }
+
             override fun parseValue(value: String): FullShowTitle =
-                Json.decodeFromString(value)
+                Json.decodeFromString(value.decodeURLQueryComponent())
+
             override fun serializeAsValue(value: FullShowTitle): String =
-                Json.encodeToString(value)
+                Json.encodeToString(value).encodeURLPath()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/gizz/tapes/data/ShowId.kt
+++ b/composeApp/src/commonMain/kotlin/gizz/tapes/data/ShowId.kt
@@ -4,14 +4,14 @@ import androidx.navigation.NavType
 import androidx.savedstate.SavedState
 import androidx.savedstate.read
 import androidx.savedstate.write
+import io.ktor.http.decodeURLQueryComponent
+import io.ktor.http.encodeURLPath
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 @Serializable
 @JvmInline
 value class ShowId(val value: String) {
-    override fun toString(): String = value
-
     companion object {
         val navType = object : NavType<ShowId>(
             isNullableAllowed = false
@@ -23,7 +23,11 @@ value class ShowId(val value: String) {
                 bundle.write { putString(key, value.value) }
 
             override fun parseValue(value: String): ShowId {
-                return ShowId(value)
+                return ShowId(value.decodeURLQueryComponent())
+            }
+
+            override fun serializeAsValue(value: ShowId): String {
+                return value.value.encodeURLPath()
             }
         }
     }


### PR DESCRIPTION
- Url encodes and decodes the title being passed to navigation
- Updated showId to also update url encode and decode