### PR TITLE
chromecast: fix crashing during playback

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,8 @@
 
 == LeRisque
 
+- Fix chromecast playback
+
 == KGLW 2026-05-30
 
 - Fix App Icon Not Loading

--- a/androidApp/src/full/kotlin/gizz/tapes/playback/CastPlayerFactory.kt
+++ b/androidApp/src/full/kotlin/gizz/tapes/playback/CastPlayerFactory.kt
@@ -2,6 +2,7 @@ package gizz.tapes.playback
 
 import android.content.Context
 import androidx.media3.cast.CastPlayer
+import androidx.media3.cast.RemoteCastPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -18,8 +19,12 @@ class CastPlayerFactory(
 ) : PlayerFactory {
     override fun create(exoPlayer: ExoPlayer): Player {
         return runCatching {
+            val remotePlayer = RemoteCastPlayer.Builder(context)
+                .setMediaItemConverter(GizzMediaItemConverter())
+                .build()
             CastPlayer.Builder(context)
                 .setLocalPlayer(exoPlayer)
+                .setRemotePlayer(remotePlayer)
                 .build()
         }.getOrElse {
             Logger.e("Error creating CastPlayer, falling back to ExoPlayer", it)

--- a/androidApp/src/full/kotlin/gizz/tapes/playback/GizzMediaItemConverter.kt
+++ b/androidApp/src/full/kotlin/gizz/tapes/playback/GizzMediaItemConverter.kt
@@ -1,0 +1,94 @@
+package gizz.tapes.playback
+
+import androidx.media3.cast.DefaultMediaItemConverter
+import androidx.media3.cast.MediaItemConverter
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+import com.google.android.gms.cast.MediaInfo
+import com.google.android.gms.cast.MediaMetadata
+import com.google.android.gms.cast.MediaQueueItem
+import org.json.JSONObject
+
+/**
+ * Wraps [DefaultMediaItemConverter] to also round-trip recording year/month/day through Cast,
+ * and to handle null customData gracefully (the default converter crashes in that case,
+ * see https://github.com/androidx/media/issues/1961).
+ */
+@UnstableApi
+internal class GizzMediaItemConverter : MediaItemConverter {
+
+    private val default = DefaultMediaItemConverter()
+
+    override fun toMediaQueueItem(mediaItem: MediaItem): MediaQueueItem {
+        val defaultItem = default.toMediaQueueItem(mediaItem)
+        val mediaInfo = defaultItem.media ?: return defaultItem
+        val contentUrl = mediaInfo.contentUrl ?: return defaultItem
+
+        val customData = (mediaInfo.customData ?: JSONObject())
+        mediaItem.mediaMetadata.recordingYear?.let { customData.put(KEY_RECORDING_YEAR, it) }
+        mediaItem.mediaMetadata.recordingMonth?.let { customData.put(KEY_RECORDING_MONTH, it) }
+        mediaItem.mediaMetadata.recordingDay?.let { customData.put(KEY_RECORDING_DAY, it) }
+
+        val newMediaInfo = MediaInfo.Builder(mediaInfo.contentId)
+            .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
+            .setContentType(mediaInfo.contentType ?: MimeTypes.AUDIO_MPEG)
+            .setContentUrl(contentUrl)
+            .setStreamDuration(mediaInfo.streamDuration)
+            .setMetadata(mediaInfo.metadata)
+            .setCustomData(customData)
+            .build()
+
+        return MediaQueueItem.Builder(newMediaInfo).build()
+    }
+
+    override fun toMediaItem(mediaQueueItem: MediaQueueItem): MediaItem {
+        val mediaInfo = mediaQueueItem.media
+        if (mediaInfo?.customData == null) {
+            return buildFallbackMediaItem(mediaInfo)
+        }
+
+        val mediaItem = default.toMediaItem(mediaQueueItem)
+        val customData = mediaInfo.customData
+        val year = customData?.optInt(KEY_RECORDING_YEAR, -1).takeIf { it != -1 } ?: return mediaItem
+        val month = customData?.optInt(KEY_RECORDING_MONTH, -1).takeIf { it != -1 } ?: return mediaItem
+        val day = customData?.optInt(KEY_RECORDING_DAY, -1).takeIf { it != -1 } ?: return mediaItem
+
+        return mediaItem.buildUpon()
+            .setMediaMetadata(
+                mediaItem.mediaMetadata.buildUpon()
+                    .setRecordingYear(year)
+                    .setRecordingMonth(month)
+                    .setRecordingDay(day)
+                    .build()
+            )
+            .build()
+    }
+
+    private fun buildFallbackMediaItem(mediaInfo: MediaInfo?): MediaItem {
+        val uri = mediaInfo?.contentUrl ?: mediaInfo?.contentId ?: return MediaItem.EMPTY
+        val builder = MediaItem.Builder().setUri(uri)
+        mediaInfo?.contentId?.let { builder.setMediaId(it) }
+        mediaInfo?.contentType?.let { builder.setMimeType(it) }
+        mediaInfo?.metadata?.let { meta ->
+            val metadataBuilder = androidx.media3.common.MediaMetadata.Builder()
+            if (meta.containsKey(MediaMetadata.KEY_TITLE)) {
+                metadataBuilder.setTitle(meta.getString(MediaMetadata.KEY_TITLE))
+            }
+            if (meta.containsKey(MediaMetadata.KEY_ALBUM_TITLE)) {
+                metadataBuilder.setAlbumTitle(meta.getString(MediaMetadata.KEY_ALBUM_TITLE))
+            }
+            if (meta.images.isNotEmpty()) {
+                metadataBuilder.setArtworkUri(meta.images[0].url)
+            }
+            builder.setMediaMetadata(metadataBuilder.build())
+        }
+        return builder.build()
+    }
+
+    companion object {
+        private const val KEY_RECORDING_YEAR = "recordingYear"
+        private const val KEY_RECORDING_MONTH = "recordingMonth"
+        private const val KEY_RECORDING_DAY = "recordingDay"
+    }
+}

--- a/androidApp/src/main/kotlin/gizz/tapes/PlaybackService.kt
+++ b/androidApp/src/main/kotlin/gizz/tapes/PlaybackService.kt
@@ -38,7 +38,7 @@ import gizz.tapes.util.MediaItemWrapper
 import gizz.tapes.util.MediaItemsWrapper
 import gizz.tapes.util.realMediaId
 import gizz.tapes.util.toMediaItems
-import gizz.tapes.util.toPlaybackItems
+import gizz.tapes.util.toPlaybackItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -283,7 +283,7 @@ class PlaybackService(
             )
         }
         currentlyPlayingSaver.save(
-            items = items.toPlaybackItems(),
+            items = items.mapNotNull { runCatching { it.toPlaybackItem() }.getOrNull() },
             currentTrackIndex = trackIndex,
             currentPosition = position
         )

--- a/composeApp/src/androidMain/kotlin/gizz/tapes/playback/AndroidMediaPlayer.kt
+++ b/composeApp/src/androidMain/kotlin/gizz/tapes/playback/AndroidMediaPlayer.kt
@@ -17,7 +17,7 @@ import dev.zacsweers.metro.SingleIn
 import gizz.tapes.ui.player.MediaDurationInfo
 import gizz.tapes.ui.player.PlayerError
 import gizz.tapes.ui.player.PlayerState
-import gizz.tapes.util.showExtras
+import gizz.tapes.util.resolveShowDestination
 import gizz.tapes.util.toMediaItems
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -106,7 +106,7 @@ class AndroidMediaPlayer(context: Context) : GizzMediaPlayer {
             _state.value = PlayerState.NoMedia
             return
         }
-        val show = cmi.showExtras ?: run {
+        val show = cmi.resolveShowDestination() ?: run {
             _state.value = PlayerState.NoMedia
             return
         }
@@ -136,7 +136,7 @@ class AndroidMediaPlayer(context: Context) : GizzMediaPlayer {
     private fun updateStateWithError(message: String) {
         val controller = mediaController ?: return
         val cmi = controller.currentMediaItem ?: return
-        val show = cmi.showExtras ?: return
+        val show = cmi.resolveShowDestination() ?: return
         val metadata = cmi.mediaMetadata
         _state.value = PlayerState.MediaLoaded.Error(
             playerError = PlayerError(message),

--- a/composeApp/src/androidMain/kotlin/gizz/tapes/util/media.kt
+++ b/composeApp/src/androidMain/kotlin/gizz/tapes/util/media.kt
@@ -5,6 +5,9 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.MimeTypes
 import gizz.tapes.data.BAND_NAME
+import gizz.tapes.data.FullShowTitle
+import gizz.tapes.data.ShowId
+import gizz.tapes.data.Title
 import gizz.tapes.nav.Destination
 import gizz.tapes.playback.MediaId
 import gizz.tapes.playback.PlaybackItem
@@ -13,6 +16,20 @@ import kotlinx.datetime.number
 
 val MediaItem?.title: String get() = this?.mediaMetadata?.title?.toString() ?: "--"
 val MediaItem.showExtras: Destination.Show? get() = mediaMetadata.extras?.toShowInfo()
+
+// CastPlayer strips Bundle extras, so fall back to standard fields that survive Cast.
+fun MediaItem.resolveShowDestination(): Destination.Show? {
+    showExtras?.let { return it }
+    val showIdStr = realMediaId.showId ?: return null
+    val albumTitle = mediaMetadata.albumTitle?.toString() ?: return null
+    val year = mediaMetadata.recordingYear ?: return null
+    val month = mediaMetadata.recordingMonth ?: return null
+    val day = mediaMetadata.recordingDay ?: return null
+    return Destination.Show(
+        id = ShowId(showIdStr),
+        title = FullShowTitle(title = Title(albumTitle), date = LocalDate(year, month, day))
+    )
+}
 fun MediaItem.Builder.setMediaId(mediaId: MediaId): MediaItem.Builder {
     return setMediaId(mediaId.id)
 }
@@ -73,7 +90,16 @@ fun Collection<PlaybackItem>.toMediaItems(): List<MediaItem> = map { it.toMediaI
 
 fun MediaItem.toPlaybackItem(): PlaybackItem {
     val metadata = mediaMetadata
-    val show = checkNotNull(showExtras) { "MediaItem missing show extras: $mediaId" }
+    val date = LocalDate(
+        year = checkNotNull(metadata.recordingYear) { "MediaItem missing recordingYear: $mediaId" },
+        month = checkNotNull(metadata.recordingMonth) { "MediaItem missing recordingMonth: $mediaId" },
+        day = checkNotNull(metadata.recordingDay) { "MediaItem missing recordingDay: $mediaId" },
+    )
+    // CastPlayer strips Bundle extras from MediaMetadata, so fall back to fields that survive Cast.
+    val show = showExtras ?: Destination.Show(
+        id = ShowId(checkNotNull(realMediaId.showId) { "MediaItem mediaId missing showId: $mediaId" }),
+        title = FullShowTitle(title = Title(metadata.albumTitle?.toString() ?: "--"), date = date)
+    )
     return PlaybackItem(
         id = mediaId,
         url = checkNotNull(localConfiguration?.uri?.toString()) { "MediaItem missing URI: $mediaId" },
@@ -83,11 +109,7 @@ fun MediaItem.toPlaybackItem(): PlaybackItem {
         showId = show.id,
         showTitle = show.title,
         durationMs = metadata.durationMs ?: 0L,
-        showDate = LocalDate(
-            year = checkNotNull(metadata.recordingYear) { "MediaItem missing recordingYear: $mediaId" },
-            month = checkNotNull(metadata.recordingMonth) { "MediaItem missing recordingMonth: $mediaId" },
-            day = checkNotNull(metadata.recordingDay) { "MediaItem missing recordingDay: $mediaId" },
-        )
+        showDate = date
     )
 }
 


### PR DESCRIPTION
Fixes issue where chromecast doesn't save metadata like the local player. We now save the media item data so that it can be recovered in order to properly show what track is playing during a chromecast session.